### PR TITLE
update the scorcher helmet

### DIFF
--- a/Patches/Rimsenal Collection/Feral/ThingDefs_Misc/Feral_Apparel.xml
+++ b/Patches/Rimsenal Collection/Feral/ThingDefs_Misc/Feral_Apparel.xml
@@ -53,13 +53,13 @@
 					<WornBulk>1.8</WornBulk>					
 				</value>
 			</li>			
-			<li Class="PatchOperationReplace">
+			<li Class="PatchOperationAdd">
 				<xpath>/Defs/ThingDef[defName="Apparel_ScorcherHelmet"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
 					<ArmorRating_Blunt>12</ArmorRating_Blunt>
 				</value>			
 			</li>
-			<li Class="PatchOperationReplace">
+			<li Class="PatchOperationAdd">
 				<xpath>/Defs/ThingDef[defName="Apparel_ScorcherHelmet"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
 					<ArmorRating_Sharp>4</ArmorRating_Sharp>


### PR DESCRIPTION
The 31.07 feral faction update changed the stats of the Scorcher Helmet, removing the blunt and sharp armor rating stats. Combat Extended is trying to replace these attributes with new values, but they no longer exist and thus the error is thrown. As such, the CE blunt and sharp armor stats are added

## Additions

Describe new functionality added by your code, e.g.
- Tribal smoke bombs
- New tribal smoke bomb sprite
- Tribal smoke bomb recipes at smithing bench and crafting spot using prometheum

## Changes

Describe adjustments to existing features made in this merge, e.g.
- Increased regular smoke bomb radius

## References

Links to the associated issues or other related pull requests, e.g.
- Closes #[ISSUE_NUMBER]
- Contributes towards #[ISSUE_NUMBER]

## Reasoning

Why did you choose to implement things this way, e.g.
- Tribals need ways to close distance with pirate raiders
- Smoke bombs allow this while enhancing combat micro
- Thematically appropriate as we already allow tribal prometheum handling
- Easy to implement
- Buffed regular smoke grenades as they are rarely utilized and to justify additional investment

## Alternatives

Describe alternative implementations you have considered, e.g.
- Tribal catapult that launches melee animals into siege camps:
  - Additional use for animals
  - Anachronistic
  - Breaks realism theme

## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
